### PR TITLE
DC ESS BUS Functions

### DIFF
--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_automation.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_automation.lua
@@ -93,12 +93,12 @@ function ecam_user_press_page_button(phase, which_page)
                 set(Ecam_current_status, ECAM_STATUS_NORMAL) 
                 -- If another mode was selected, page will change automatically at next sasl run
             else
-                Goto_ecam(which_page)        
+                if get(DC_ess_bus_pwrd) == 1 then Goto_ecam(which_page) end
             end
         else
             -- Change the page in *any* case (forced by user)
             set(Ecam_current_status,ECAM_STATUS_SHOW_USER)
-            Goto_ecam(which_page)
+            if get(DC_ess_bus_pwrd) == 1 then Goto_ecam(which_page) end
         end
         press_start_time = get(TIME)
     elseif phase == SASL_COMMAND_CONTINUE then  -- Fail of ecam

--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_automation.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_automation.lua
@@ -83,7 +83,7 @@ local function Goto_ecam(page_num)
 end
 
 function ecam_user_press_page_button(phase, which_page)
-    if phase == SASL_COMMAND_BEGIN and get(DC_ess_bus_pwrd) == 1 then
+    if phase == SASL_COMMAND_BEGIN and (get(DC_ess_bus_pwrd) == 1 or which_page == 12) then
         if get(Ecam_current_status) == ECAM_STATUS_SHOW_USER then
             -- We are already in user mode
 

--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_automation.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_automation.lua
@@ -83,7 +83,7 @@ local function Goto_ecam(page_num)
 end
 
 function ecam_user_press_page_button(phase, which_page)
-    if phase == SASL_COMMAND_BEGIN then
+    if phase == SASL_COMMAND_BEGIN and get(DC_ess_bus_pwrd) == 1 then
         if get(Ecam_current_status) == ECAM_STATUS_SHOW_USER then
             -- We are already in user mode
 
@@ -93,12 +93,12 @@ function ecam_user_press_page_button(phase, which_page)
                 set(Ecam_current_status, ECAM_STATUS_NORMAL) 
                 -- If another mode was selected, page will change automatically at next sasl run
             else
-                if get(DC_ess_bus_pwrd) == 1 then Goto_ecam(which_page) end
+                Goto_ecam(which_page)
             end
         else
             -- Change the page in *any* case (forced by user)
             set(Ecam_current_status,ECAM_STATUS_SHOW_USER)
-            if get(DC_ess_bus_pwrd) == 1 then Goto_ecam(which_page) end
+            Goto_ecam(which_page)
         end
         press_start_time = get(TIME)
     elseif phase == SASL_COMMAND_CONTINUE then  -- Fail of ecam

--- a/plugins/sasl/data/modules/Custom Module/GPWS.lua
+++ b/plugins/sasl/data/modules/Custom Module/GPWS.lua
@@ -552,6 +552,9 @@ local function check_inop()
 end
 
 function update()
+
+    if get(DC_ess_bus_pwrd) == 0 then set(FAILURE_GPWS, 1) else set(FAILURE_GPWS, 0) end
+
     perf_measure_start("GPWS:update()")
 
     is_warning = false

--- a/plugins/sasl/data/modules/Custom Module/GPWS.lua
+++ b/plugins/sasl/data/modules/Custom Module/GPWS.lua
@@ -552,9 +552,6 @@ local function check_inop()
 end
 
 function update()
-
-    if get(DC_ess_bus_pwrd) == 0 then set(FAILURE_GPWS, 1) else set(FAILURE_GPWS, 0) end
-
     perf_measure_start("GPWS:update()")
 
     is_warning = false


### PR DESCRIPTION
Upon loss of DC ESS BUS power, ECAM actions (except ALL, RCL, CLR, EMER CMD, and STS) are inop, and the GPWS fails.