### PR TITLE
add park brake/autobrake support required by Airbus TCA switch/button…

### DIFF
--- a/plugins/sasl/data/modules/Custom Module/cockpit_commands.lua
+++ b/plugins/sasl/data/modules/Custom Module/cockpit_commands.lua
@@ -64,7 +64,12 @@ Toggle_med_autobrake = createCommand("a321neo/cockpit/wheel/toggle_med_autobrake
 Toggle_max_autobrake = createCommand("a321neo/cockpit/wheel/toggle_max_autobrake", "Toggle MAX autobrake")
 Toggle_antiskid_ns   = createCommand("a321neo/cockpit/wheel/toggle_antiskid_ns", "Toggle A/SKID and N/W STRG")
 Toggle_park_brake    = createCommand("a321neo/cockpit/wheel/toggle_park_brake", "Toggle Park Brake")
-
+-- Airbus TCA support - TCA quadrant has a dial switch and no toggle push buttons
+TCA_disable_autobrake= createCommand("a321neo/cockpit/wheel/autobrake_disable", "Disable autobrake")
+TCA_lo_autobrake     = createCommand("a321neo/cockpit/wheel/lo_autobrake_on", "Activate LO autobrake")
+TCA_med_autobrake    = createCommand("a321neo/cockpit/wheel/med_autobrake_on", "Activate MED autobrake")
+TCA_max_autobrake    = createCommand("a321neo/cockpit/wheel/max_autobrake_on", "Activate MAX autobrake")
+TCA_park_brake_set   = createCommand("a321neo/cockpit/wheel/park_break_set", "Set parking brake")
 Toggle_park_brake_XP    = findCommand("sim/flight_controls/brakes_toggle_max")
 Push_brake_regular_XP = findCommand("sim/flight_controls/brakes_regular")
 Toggle_brake_regular_XP = findCommand("sim/flight_controls/brakes_toggle_regular")

--- a/plugins/sasl/data/modules/Custom Module/cockpit_commands.lua
+++ b/plugins/sasl/data/modules/Custom Module/cockpit_commands.lua
@@ -66,9 +66,6 @@ Toggle_antiskid_ns   = createCommand("a321neo/cockpit/wheel/toggle_antiskid_ns",
 Toggle_park_brake    = createCommand("a321neo/cockpit/wheel/toggle_park_brake", "Toggle Park Brake")
 -- Airbus TCA support - TCA quadrant has a dial switch and no toggle push buttons
 TCA_disable_autobrake= createCommand("a321neo/cockpit/wheel/autobrake_disable", "Disable autobrake")
-TCA_lo_autobrake     = createCommand("a321neo/cockpit/wheel/lo_autobrake_on", "Activate LO autobrake")
-TCA_med_autobrake    = createCommand("a321neo/cockpit/wheel/med_autobrake_on", "Activate MED autobrake")
-TCA_max_autobrake    = createCommand("a321neo/cockpit/wheel/max_autobrake_on", "Activate MAX autobrake")
 TCA_park_brake_set   = createCommand("a321neo/cockpit/wheel/park_break_set", "Set parking brake")
 Toggle_park_brake_XP    = findCommand("sim/flight_controls/brakes_toggle_max")
 Push_brake_regular_XP = findCommand("sim/flight_controls/brakes_regular")

--- a/plugins/sasl/data/modules/Custom Module/wheel.lua
+++ b/plugins/sasl/data/modules/Custom Module/wheel.lua
@@ -69,7 +69,16 @@ sasl.registerCommandHandler (Toggle_park_brake, 0, function(phase) Toggle_parkbr
 sasl.registerCommandHandler (Toggle_park_brake_XP, 0, function(phase) Toggle_parkbrake(phase) end)
 sasl.registerCommandHandler (Toggle_brake_regular_XP, 0, function(phase) Toggle_regular(phase) end)
 sasl.registerCommandHandler (Push_brake_regular_XP, 0, function(phase) Braking_regular(phase) end)
+-- Airbus TCA support
+sasl.registerCommandHandler (TCA_park_brake_set, 0, function(phase) Set_parkbrake(phase) end)
 
+function Set_parkbrake(phase)
+  if phase == SASL_COMMAND_CONTINUE then
+        set(Parkbrake_switch_pos, 1)
+    else
+        set(Parkbrake_switch_pos, 0)
+    end  
+end
 
 function Toggle_parkbrake(phase)
     if phase == SASL_COMMAND_BEGIN then

--- a/plugins/sasl/data/modules/Custom Module/wheel_autobrake.lua
+++ b/plugins/sasl/data/modules/Custom Module/wheel_autobrake.lua
@@ -65,6 +65,11 @@ local pid_array = {
 sasl.registerCommandHandler (Toggle_lo_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_LOW)  end)
 sasl.registerCommandHandler (Toggle_med_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_MED) end)
 sasl.registerCommandHandler (Toggle_max_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_MAX) end)
+-- Airbus TCA support
+sasl.registerCommandHandler (TCA_disable_autobrake, 0, function(phase) set(Wheel_autobrake_status, AUTOBRK_OFF) end)
+sasl.registerCommandHandler (TCA_lo_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_LOW) end)
+sasl.registerCommandHandler (TCA_med_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_MED) end)
+sasl.registerCommandHandler (TCA_max_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_MAX) end)
 
 
 function Toggle_autobrake(phase, value)

--- a/plugins/sasl/data/modules/Custom Module/wheel_autobrake.lua
+++ b/plugins/sasl/data/modules/Custom Module/wheel_autobrake.lua
@@ -67,9 +67,6 @@ sasl.registerCommandHandler (Toggle_med_autobrake, 0, function(phase) Toggle_aut
 sasl.registerCommandHandler (Toggle_max_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_MAX) end)
 -- Airbus TCA support
 sasl.registerCommandHandler (TCA_disable_autobrake, 0, function(phase) set(Wheel_autobrake_status, AUTOBRK_OFF) end)
-sasl.registerCommandHandler (TCA_lo_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_LOW) end)
-sasl.registerCommandHandler (TCA_med_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_MED) end)
-sasl.registerCommandHandler (TCA_max_autobrake, 0, function(phase) Toggle_autobrake(phase, AUTOBRK_MAX) end)
 
 
 function Toggle_autobrake(phase, value)


### PR DESCRIPTION
Proposal for changes required to support Thrustmaster Airbus TCA quadrant add on.
The autobrake settings hardware is implemented with a dial switch with discrete positions and not as a toggle.
Thererfore a different logic triggered by the new commands seems to be required.
Also the park break of the quadrant is implemented as a kind of push button and not two discrete switches or a toggle.