### PR TITLE
add Airbus TCA support for Engine Master and Mode switches

### DIFF
--- a/plugins/sasl/data/modules/Custom Module/cockpit_commands.lua
+++ b/plugins/sasl/data/modules/Custom Module/cockpit_commands.lua
@@ -271,6 +271,14 @@ ENG_cmd_mode_up        = sasl.createCommand("a321neo/cockpit/engine/mode_up", "e
 ENG_cmd_mode_down      = sasl.createCommand("a321neo/cockpit/engine/mode_dn", "engine mode selector down")
 ENG_cmd_master_toggle_1= createCommand("a321neo/cockpit/engine/master_toggle_1", "Master Switch ENG1")
 ENG_cmd_master_toggle_2= createCommand("a321neo/cockpit/engine/master_toggle_2", "Master Switch ENG2")
+-- Airbus TCA support
+ENG_cmd_mode_ignite    = sasl.createCommand("a321neo/cockpit/engine/mode_ignite", "engine mode selector IGN/START")
+ENG_cmd_mode_norm      = sasl.createCommand("a321neo/cockpit/engine/mode_norm", "engine mode selector NORM")
+ENG_cmd_mode_crank     = sasl.createCommand("a321neo/cockpit/engine/mode_crank", "engine mode selector CRANK")
+ENG_cmd_master_on_1    = sasl.createCommand("a321neo/cockpit/engine/master_on_1", "Master Switch ENG1 on")
+ENG_cmd_master_off_1   = sasl.createCommand("a321neo/cockpit/engine/master_off_1", "Master Switch ENG1 off")
+ENG_cmd_master_on_2    = sasl.createCommand("a321neo/cockpit/engine/master_on_2", "Master Switch ENG2 on")
+ENG_cmd_master_off_2   = sasl.createCommand("a321neo/cockpit/engine/master_off_2", "Master Switch ENG2 off")
 
 -- APU
 APU_cmd_master = sasl.createCommand("a321neo/cockpit/engine/apu_master_toggle", "toggle APU master button")

--- a/plugins/sasl/data/modules/Custom Module/engines.lua
+++ b/plugins/sasl/data/modules/Custom Module/engines.lua
@@ -160,6 +160,14 @@ function engines_mode_down(phase)
     return 1
 end
 
+-- to support TCA quadrant switch we need to explicitly set the mode
+function engines_mode(phase,mode)
+    if phase == SASL_COMMAND_BEGIN then
+        set(Engine_mode_knob, mode)
+    end
+    return 1
+end
+
 ----------------------------------------------------------------------------------------------------
 -- Commands
 ----------------------------------------------------------------------------------------------------
@@ -169,10 +177,18 @@ sasl.registerCommandHandler (ENG_cmd_dual_cooling,    0, function(phase) if phas
 
 sasl.registerCommandHandler (ENG_cmd_master_toggle_1, 0, function(phase) if phase == SASL_COMMAND_BEGIN then set(Engine_1_master_switch, 1-get(Engine_1_master_switch)) end end )
 sasl.registerCommandHandler (ENG_cmd_master_toggle_2, 0, function(phase) if phase == SASL_COMMAND_BEGIN then set(Engine_2_master_switch, 1-get(Engine_2_master_switch)) end end )
-
+-- Airbus TCA support
+sasl.registerCommandHandler (ENG_cmd_master_on_1, 0, function(phase) if phase == SASL_COMMAND_BEGIN then set(Engine_1_master_switch, 1) end end )
+sasl.registerCommandHandler (ENG_cmd_master_off_1, 0, function(phase) if phase == SASL_COMMAND_BEGIN then set(Engine_1_master_switch, 0) end end )
+sasl.registerCommandHandler (ENG_cmd_master_on_2, 0, function(phase) if phase == SASL_COMMAND_BEGIN then set(Engine_2_master_switch, 1) end end )
+sasl.registerCommandHandler (ENG_cmd_master_off_2, 0, function(phase) if phase == SASL_COMMAND_BEGIN then set(Engine_2_master_switch, 0) end end )
 
 sasl.registerCommandHandler (ENG_cmd_mode_up,            0, function(phase) engines_mode_up(phase) end)
 sasl.registerCommandHandler (ENG_cmd_mode_down,          0, function(phase) engines_mode_down(phase) end)
+-- Airbus TCA support
+sasl.registerCommandHandler (ENG_cmd_mode_ignite,        0, function(phase) engines_mode(phase,1) end)
+sasl.registerCommandHandler (ENG_cmd_mode_norm,          0, function(phase) engines_mode(phase,0) end)
+sasl.registerCommandHandler (ENG_cmd_mode_crank,         0, function(phase) engines_mode(phase,-1) end)
 sasl.registerCommandHandler (sasl.findCommand("sim/operation/auto_start"),  1, engines_auto_slow_start )
 sasl.registerCommandHandler (sasl.findCommand("sim/operation/quick_start"), 1, engines_auto_quick_start )
 


### PR DESCRIPTION
Thrustmaster Airbus TCA throttle quadrant support.
Engine mode and master switches are implemented as discrete switch values and not toggles.
Therefore it seems neccessary to add new commands to support the TCA hardware.

This is a proposal for an implementation which works in my setup.