### PR TITLE
refactor - use flight phase constants instead of numeric value in all…

### DIFF
--- a/plugins/sasl/data/modules/Custom Module/DCDU.lua
+++ b/plugins/sasl/data/modules/Custom Module/DCDU.lua
@@ -502,7 +502,7 @@ local function update_connected_atc()
     end
 
     -- But if we are airbone, let's switch to ACC
-    if get(EWD_flight_phase) == 6 and nearest_ctr ~= nil then
+    if get(EWD_flight_phase) == PHASE_AIRBONE and nearest_ctr ~= nil then
         temp_atc_id   = nearest_ctr[1]
         temp_atc_name = nearest_ctr[2] .. " ACC"
     end

--- a/plugins/sasl/data/modules/Custom Module/ECAM.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM.lua
@@ -268,7 +268,7 @@ function draw()
     -- Update STS box
     set(EWD_box_sts, 0)
     set(Ecam_status_is_normal, ecam_sts:is_normal() and 1 or 0) -- Used in ECAM_automation.lua
-    if (not ecam_sts:is_normal()) or (not ecam_sts:is_normal_maintenance() and get(EWD_flight_phase) == 10 ) then
+    if (not ecam_sts:is_normal()) or (not ecam_sts:is_normal_maintenance() and get(EWD_flight_phase) == PHASE_2ND_ENG_OFF ) then
         if get(Ecam_current_status) ~= ECAM_STATUS_SHOW_EWD_STS and get(Ecam_current_status) ~= ECAM_STATUS_SHOW_EWD then
             set(EWD_box_sts, 1)
         end

--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_fuel.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_fuel.lua
@@ -163,7 +163,7 @@ local function draw_fuel_usage_and_ff()
     fuel_usage_2 = fuel_usage_2 - fuel_usage_2 % 10
     local fuel_usage_tot = fuel_usage_1 + fuel_usage_2
 
-    local color = get(EWD_flight_phase) >= 2 and ECAM_GREEN or ECAM_WHITE
+    local color = get(EWD_flight_phase) >= PHASE_1ST_ENG_ON and ECAM_GREEN or ECAM_WHITE
 
     sasl.gl.drawText(Font_AirbusDUL, size[2]/2-220, size[2]-110, fuel_usage_1, 36, false, false, TEXT_ALIGN_CENTER, color)
     sasl.gl.drawText(Font_AirbusDUL, size[2]/2+220, size[2]-110, fuel_usage_2, 36, false, false, TEXT_ALIGN_CENTER, color)

--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_status/logic_checks.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_status/logic_checks.lua
@@ -36,7 +36,7 @@ end
 
 function engine_shuts_down()
     return (get(Engine_1_master_switch) == 0 and get(EWD_flight_phase) >= PHASE_ABOVE_80_KTS and get(EWD_flight_phase) <= PHASE_TOUCHDOWN)
-    or ((get(EWD_flight_phase) < 3 or get(EWD_flight_phase) > 8) and get(Fire_pb_ENG1_status) == 1)
+    or ((get(EWD_flight_phase) < PHASE_1ST_ENG_TO_PWR or get(EWD_flight_phase) > PHASE_TOUCHDOWN) and get(Fire_pb_ENG1_status) == 1)
 end
 
 function spdbrk_3_and_4_fault() --fcom 5231

--- a/plugins/sasl/data/modules/Custom Module/EWD.lua
+++ b/plugins/sasl/data/modules/Custom Module/EWD.lua
@@ -72,7 +72,7 @@ end
 
 local function get_reverse_color(x)
     local reverse_pos = x == 1 and get(Eng_1_reverser_deployment) or get(Eng_2_reverser_deployment)
-    if get(EWD_flight_phase) >= 5 and get(EWD_flight_phase) <= 7 then
+    if get(EWD_flight_phase) >= PHASE_LIFTOFF and get(EWD_flight_phase) <= PHASE_FINAL then
         return ((math.floor(get(TIME)*2) % 2) == 1 and ECAM_RED or ECAM_ORANGE) -- Blink
     elseif reverse_pos > 0.98 then
         return ECAM_GREEN

--- a/plugins/sasl/data/modules/Custom Module/EWD_msgs/misc.lua
+++ b/plugins/sasl/data/modules/Custom Module/EWD_msgs/misc.lua
@@ -175,14 +175,14 @@ MessageGroup_IRS_ALIGN = {
                 end
             
                 local minutes = math.floor(time_max / 60)
-                if get(EWD_flight_phase) <= 2 then
+                if get(EWD_flight_phase) <= PHASE_1ST_ENG_ON then
                     return "IRS IN ALIGN " .. minutes .. " MN"
                 else
                     return "IRS IN ALIGN"
                 end
             end,
             color = function(self)
-                if get(EWD_flight_phase) <= 1 then
+                if get(EWD_flight_phase) <= PHASE_ELEC_PWR then
                     return COL_INDICATION
                 else
                     return COL_CAUTION                


### PR DESCRIPTION
For an easier onboarding of new developers it would be helpful to use symbolic constant values in all places.
So this is the refactoring regarding flight phases. Pls check for correct replacement.

I also found a typo in PHASE_AIRBOrNE but this would affect many files, so I did not refactor that yet.