### PR TITLE
(APU/ENG) several small improvements

### DIFF
--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_apu.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_apu.lua
@@ -105,8 +105,8 @@ function draw_apu_page()
 
     end
 
-    --apu bleed--
-    if ADIRS_sys[ADIRS_1].adr_status ~= ADR_STATUS_ON or ADIRS_sys[ADIRS_2].adr_status ~= ADR_STATUS_ON or (get(FAILURE_BLEED_BMC_1) == 1 and get(FAILURE_BLEED_BMC_2) == 1) or get(Apu_bleed_xplane) == 0 then
+    --apu bleed-- display of XX depends only on ADR status, not on bleed switch according videos
+    if ADIRS_sys[ADIRS_1].adr_status ~= ADR_STATUS_ON or ADIRS_sys[ADIRS_2].adr_status ~= ADR_STATUS_ON or (get(FAILURE_BLEED_BMC_1) == 1 and get(FAILURE_BLEED_BMC_2) == 1)  then
         sasl.gl.drawText(Font_AirbusDUL, size[1]/2+265, size[2]/2+187, "XX", 26, false, false, TEXT_ALIGN_RIGHT, ECAM_ORANGE)
     else
         sasl.gl.drawText(Font_AirbusDUL, size[1]/2+265, size[2]/2+187, math.floor(get(Apu_bleed_psi)), 26, false, false, TEXT_ALIGN_RIGHT, ECAM_GREEN)

--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_engines.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_engines.lua
@@ -97,11 +97,11 @@ local function draw_oil_qt_press_temp_eng_1()
         -- ENG 1 OIL PRESS
         ------------------------------------------------------------------------------------
         local eng_1_oil_color = pulse_green(
-              params.eng1_oil_press > ENG.data.display.oil_press_high_adv or 
+              params.eng1_oil_press > ENG.data.display.oil_press_high_adv or
               params.eng1_oil_press < ENG.data.display.oil_press_low_adv
               )
 
-        -- TODO in lower N2 range this seems to be not the correct formula to compute the limits?
+        --- N dependent limits may override actual color
         local press_red_limit = get_press_red_limit(get(Eng_1_N2))
         local press_amber_limit = get_press_amber_limit(get(Eng_1_N2))
 
@@ -147,7 +147,7 @@ local function draw_oil_qt_press_temp_eng_2()
         -- ENG 2 OIL PRESS
         ------------------------------------------------------------------------------------
         local eng_2_oil_color = pulse_green(
-              params.eng2_oil_press > ENG.data.display.oil_press_high_adv or 
+              params.eng2_oil_press > ENG.data.display.oil_press_high_adv or
               params.eng2_oil_press < ENG.data.display.oil_press_low_adv
               )
 
@@ -191,8 +191,9 @@ local function draw_vibrations()
 
 
     if xx_statuses[1] and get(AC_bus_1_pwrd) == 1 then
-        local eng1_vib1_color = pulse_green(params.eng1_vib_n1 > ENG.data.vibrations.max_n1_nominal)
-        local eng1_vib2_color = pulse_green(params.eng1_vib_n2 > ENG.data.vibrations.max_n2_nominal)
+
+        local eng1_vib1_color = params.eng1_vib_n1 > ENG.data.vibrations.max_n1_nominal and ECAM_ORANGE or ECAM_GREEN
+        local eng1_vib2_color = params.eng1_vib_n2 > ENG.data.vibrations.max_n2_nominal and ECAM_ORANGE or ECAM_GREEN
         sasl.gl.drawText(Font_AirbusDUL, size[1]/2-175, 385, math.floor(params.eng1_vib_n1) .. "." , 36,
                      false, false, TEXT_ALIGN_RIGHT, eng1_vib1_color)
         sasl.gl.drawText(Font_AirbusDUL, size[1]/2-155, 385, math.floor((params.eng1_vib_n1%1)*10), 28,
@@ -209,8 +210,8 @@ local function draw_vibrations()
     end
 
     if xx_statuses[2] and get(AC_bus_1_pwrd) == 1 then
-        local eng2_vib1_color = pulse_green(params.eng2_vib_n1 > ENG.data.vibrations.max_n1_nominal)
-        local eng2_vib2_color = pulse_green(params.eng2_vib_n2 > ENG.data.vibrations.max_n2_nominal)
+        local eng2_vib1_color = params.eng2_vib_n1 > ENG.data.vibrations.max_n1_nominal and ECAM_ORANGE or ECAM_GREEN
+        local eng2_vib2_color = params.eng2_vib_n2 > ENG.data.vibrations.max_n2_nominal and ECAM_ORANGE or ECAM_GREEN
 
         sasl.gl.drawText(Font_AirbusDUL, size[1]/2+200, 385, math.floor(params.eng2_vib_n1) .. "." , 36,
                         false, false, TEXT_ALIGN_RIGHT, eng2_vib1_color)

--- a/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_engines.lua
+++ b/plugins/sasl/data/modules/Custom Module/ECAM/ECAM_engines.lua
@@ -67,10 +67,13 @@ local function pulse_green(condition)
 end
 
 local function get_press_red_limit(n2)
+    -- TODO if N2 is < 10 this will has to be calculated in some other way TBC with manuals/sim
+    if n2 < 15 then return 5 end
     return ENG.data.display.oil_press_low_red[1] + ENG.data.display.oil_press_low_red[2] * n2
 end
 
 local function get_press_amber_limit(n2)
+    if n2 < 15 then return 7 end
     return ENG.data.display.oil_press_low_amber[1] + ENG.data.display.oil_press_low_amber[2] * n2
 end
 
@@ -98,6 +101,7 @@ local function draw_oil_qt_press_temp_eng_1()
               params.eng1_oil_press < ENG.data.display.oil_press_low_adv
               )
 
+        -- TODO in lower N2 range this seems to be not the correct formula to compute the limits?
         local press_red_limit = get_press_red_limit(get(Eng_1_N2))
         local press_amber_limit = get_press_amber_limit(get(Eng_1_N2))
 
@@ -148,7 +152,7 @@ local function draw_oil_qt_press_temp_eng_2()
               )
 
         local press_red_limit = get_press_red_limit(get(Eng_2_N2))
-        local press_amber_limit = get_press_amber_limit(get(Eng_1_N2))
+        local press_amber_limit = get_press_amber_limit(get(Eng_2_N2))
 
         if params.eng2_oil_press < press_red_limit then
             eng_2_oil_color = ECAM_RED
@@ -325,7 +329,7 @@ local function draw_needle_and_valves()
 
         draw_arcs_limits(size[1]/2-189, size[2]/2+78, oil_angle_red, oil_angle_amber, oil_angle, false)
 
-        SASL_drawSegmentedImgColored_xcenter_aligned(ECAM_ENG_valve_img, size[1]/2-190, size[2]/2-272, 128, 80, 2, get(ENG_1_bleed_switch) == 1 and 2 or 1, ECAM_GREEN)
+        SASL_drawSegmentedImgColored_xcenter_aligned(ECAM_ENG_valve_img, size[1]/2-190, size[2]/2-272, 128, 80, 2, get(Eng_starter_valve_open,1) == 1 and 2 or 1, ECAM_GREEN)
     end
     
     if xx_statuses[2] then
@@ -342,7 +346,7 @@ local function draw_needle_and_valves()
 
         draw_arcs_limits(size[1]/2+189, size[2]/2+78, oil_angle_red, oil_angle_amber, oil_angle, false)
 
-        SASL_drawSegmentedImgColored_xcenter_aligned(ECAM_ENG_valve_img, size[1]/2+190, size[2]/2-272, 128, 80, 2, get(ENG_2_bleed_switch) == 1 and 2 or 1, ECAM_GREEN)
+        SASL_drawSegmentedImgColored_xcenter_aligned(ECAM_ENG_valve_img, size[1]/2+190, size[2]/2-272, 128, 80, 2, get(Eng_starter_valve_open,2) == 1 and 2 or 1, ECAM_GREEN)
     end
 end
 
@@ -366,7 +370,11 @@ local function draw_eng_bgd()
     drawTextCentered(Font_ECAMfont, 450, 478, "°C", 30, false, false, TEXT_ALIGN_CENTER, ECAM_BLUE)
     drawTextCentered(Font_ECAMfont, 450, 398, "VIB N1", 30, false, false, TEXT_ALIGN_CENTER, ECAM_WHITE)
     drawTextCentered(Font_ECAMfont, 450+30, 360, "N2", 30, false, false, TEXT_ALIGN_CENTER, ECAM_WHITE)
-    drawTextCentered(Font_ECAMfont, 450, 258, "IGN", 30, false, false, TEXT_ALIGN_CENTER, ECAM_WHITE)
+    -- draw IGN only, if eng mode is in start position TODO check valve/gauge display conditions
+    if(get(Engine_mode_knob) == 1) then
+        drawTextCentered(Font_ECAMfont, 450, 258, "IGN", 30, false, false, TEXT_ALIGN_CENTER, ECAM_WHITE)
+    end
+    -- TODO NAC temperature advisory threshold reached - draw engine nacelle temperature indication
     drawTextCentered(Font_ECAMfont, 450, 150, "PSI", 30, false, false, TEXT_ALIGN_CENTER, ECAM_BLUE)
 
     drawTextCentered(Font_ECAMfont, 93, 870, "ENGINE", 44, false, false, TEXT_ALIGN_CENTER, ECAM_WHITE)

--- a/plugins/sasl/data/modules/Custom Module/EWD.lua
+++ b/plugins/sasl/data/modules/Custom Module/EWD.lua
@@ -349,7 +349,7 @@ end
 
 local function draw_engines_extra()
 
-    -- N2 background box --
+    -- N2 grey background box -- show as long ENG is starting up but not fully available
     if get(Engine_1_master_switch) == 1 and get(Engine_1_avail) == 0 and get(EWD_engine_1_XX) == 0 then
           sasl.gl.drawRectangle(size[1]/2-210, size[2]/2+70, 85, 32, {0.2,0.2,0.2})
     end
@@ -360,7 +360,6 @@ local function draw_engines_extra()
     if get(EWD_engine_1_XX) == 0 then
         --N2--
         local n2_color_1 = params.eng1_n2 > 117 and ECAM_RED or ECAM_GREEN
-        -- TODO draw box with grey background in lower N2 range?
         sasl.gl.drawText(Font_ECAMfont, size[1]/2-145, size[2]/2+75, math.floor(params.eng1_n2) .. "." , 30, false, false, TEXT_ALIGN_RIGHT, n2_color_1)
         sasl.gl.drawText(Font_ECAMfont, size[1]/2-130, size[2]/2+75, math.floor((params.eng1_n2%1)*10) , 24, false, false, TEXT_ALIGN_RIGHT, n2_color_1)
 

--- a/plugins/sasl/data/modules/Custom Module/EWD.lua
+++ b/plugins/sasl/data/modules/Custom Module/EWD.lua
@@ -360,6 +360,7 @@ local function draw_engines_extra()
     if get(EWD_engine_1_XX) == 0 then
         --N2--
         local n2_color_1 = params.eng1_n2 > 117 and ECAM_RED or ECAM_GREEN
+        -- TODO draw box with grey background in lower N2 range?
         sasl.gl.drawText(Font_ECAMfont, size[1]/2-145, size[2]/2+75, math.floor(params.eng1_n2) .. "." , 30, false, false, TEXT_ALIGN_RIGHT, n2_color_1)
         sasl.gl.drawText(Font_ECAMfont, size[1]/2-130, size[2]/2+75, math.floor((params.eng1_n2%1)*10) , 24, false, false, TEXT_ALIGN_RIGHT, n2_color_1)
 

--- a/plugins/sasl/data/modules/Custom Module/EWD_msgs/engines_and_apu.lua
+++ b/plugins/sasl/data/modules/Custom Module/EWD_msgs/engines_and_apu.lua
@@ -660,7 +660,7 @@ MessageGroup_ENG_1_FIRE_GROUND = {
     },
 
     is_active = function()
-        return get(FAILURE_FIRE_ENG_1) == 1 and FIRE_sys.eng[1].still_on_fire and get(All_on_ground) == 1
+        return (( get(FAILURE_FIRE_ENG_1) == 1 and FIRE_sys.eng[1].still_on_fire) or FIRE_sys.eng[1].on_test)  and get(All_on_ground) == 1
     end,
 
     is_inhibited = function()
@@ -698,7 +698,7 @@ MessageGroup_ENG_2_FIRE_GROUND = {
     },
 
     is_active = function()
-        return get(FAILURE_FIRE_ENG_2) == 1 and FIRE_sys.eng[2].still_on_fire and get(All_on_ground) == 1
+        return (( get(FAILURE_FIRE_ENG_2) == 1 and FIRE_sys.eng[2].still_on_fire) or FIRE_sys.eng[2].on_test)  and get(All_on_ground) == 1
     end,
 
     is_inhibited = function()

--- a/plugins/sasl/data/modules/Custom Module/apu.lua
+++ b/plugins/sasl/data/modules/Custom Module/apu.lua
@@ -46,7 +46,7 @@ local random_egt_apu_last_update = 0
 -- Init
 ----------------------------------------------------------------------------------------------------
 function onAirportLoaded()
-    set(Apu_bleed_xplane, 0)
+    set(Apu_bleed_xplane, 0)  -- initially we want to have APU bleed switch off in any case
     set(APU_EGT, get(OTA))
 end
 ----------------------------------------------------------------------------------------------------

--- a/plugins/sasl/data/modules/Custom Module/apu.lua
+++ b/plugins/sasl/data/modules/Custom Module/apu.lua
@@ -24,9 +24,9 @@
 -- Constants
 ----------------------------------------------------------------------------------------------------
 
-local FLAP_OPEN_TIME_SEC = 20
-local FLAP_CLOSE_N2 = 5         -- flap does not close immediately on master switch off but based on N2
-local APU_START_WAIT_TIME = 5
+local FLAP_OPEN_TIME_SEC = 27   -- https://www.youtube.com/watch?v=qKbQVewLua8
+local FLAP_CLOSE_N2 = 7.5         -- flap does not close immediately on master switch off but based on N2
+local APU_START_WAIT_TIME = 5   -- ECB initialisation takes some time, delay from master switch on until start button indication goes on
 local APU_TEST_TIME = 20
 
 ----------------------------------------------------------------------------------------------------
@@ -162,7 +162,7 @@ local function update_apu_flap()
             end
         end
         -- APU flap closes only below a certain N1, see https://www.youtube.com/watch?v=Ye8y90KD1JA
-        if apu_n1 < FLAP_CLOSE_N2 then set(APU_flap, 0) end
+        if apu_n1 <= FLAP_CLOSE_N2 then set(APU_flap, 0) end
     end
 end
 

--- a/plugins/sasl/data/modules/Custom Module/dynamic_datarefs.lua
+++ b/plugins/sasl/data/modules/Custom Module/dynamic_datarefs.lua
@@ -322,7 +322,8 @@ Eng_1_Firewall_valve = createGlobalPropertyi("a321neo/dynamics/engines/eng_1_fir
 Eng_2_Firewall_valve = createGlobalPropertyi("a321neo/dynamics/engines/eng_2_firewall_valve_2", 1, false, true, false) -- 0 open, 1 - closed, 2 : transit - firewall valve
 
 Eng_spool_time = globalProperty("sim/aircraft/engine/acf_spooltime_turbine")
-Eng_is_spooling_up  = createGlobalPropertyia("a321neo/dynamics/engines/is_spooling_up", 2)
+Eng_is_spooling_up  = createGlobalPropertyia("a321neo/dynamics/engines/is_spooling_up", 2) -- cranking
+Eng_starter_valve_open  = createGlobalPropertyia("a321neo/dynamics/engines/sav_open", 2)  -- valve open time exceeds spool up so we need a separate property
 
 Eng_is_failed = createGlobalPropertyia("a321neo/dynamics/engines/eng_failed", 2) -- There's a special condition for this
 


### PR DESCRIPTION
(ENG) improve starter valve position handling
(ENG) fix eng no typo in oil pressure amber limit for ENG 2
(ENG) add some first attempt of oil pressure color handling for low N2 values (to be validated so)
(APU) add more realistic APU flap close behaviour
(APU) Implement EWD Messages and Master Caution on ENG 1/2 fire test (on ground)
(ENG) show ENG vibrations in amber in case of advisory limit exceedance (acc. PW1100 MSN FCOM)
(APU) small timing adjustments for flap open
(APU) show PSI also, if APU bleed is off (acc. video https://www.youtube.com/watch?v=qKbQVewLua8)

add some TODOs and logic explanations for faster onboarding